### PR TITLE
Add Schema.org JSON-LD plugin to Quartz plugins list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,7 @@ Quartz is a fast, batteries-included static-site generator that transforms Markd
 - [Jupyter Notebook Embed](https://github.com/vazome/quartz-jupyter-embed-display) - A minimal Quartz plugin for embedding and displaying Jupyter notebooks.
 - [Code Runner](https://github.com/Gassandrid/Quartz_CodeRunner_Plugin) - A simple, asynchronous Python code runner plugin for Quartz. This plugin allows you to run Python code blocks directly within your Quartz notes, providing a convenient way to execute and view the output of your Python scripts.
 - [Auto Card Link Renderer](https://github.com/Rerurate514/AutoCardLinkRenderer) - It enables rendering of the Obsidian plugin: AutoCardLinkTitle in Quartz.
+- [Schema.org JSON-LD](https://github.com/billhector/quartz-schema-jsonld) - Emits schema.org JSON-LD structured data into every page's head (Person, CreativeWork, Article, BreadcrumbList, WebSite, Organization) driven by frontmatter type, with BreadcrumbList from the slug path and frontmatter passthrough for image, sameAs, author, datePublished, and dateModified.
 
 <!-- END CONTENT -->
 


### PR DESCRIPTION
Adds [quartz-schema-jsonld](https://github.com/billhector/quartz-schema-jsonld) to the **Quartz plugins** section.

## What the plugin does

Drops a single `<script type="application/ld+json">` `@graph` block into every page's `<head>`, driven by frontmatter `type:`. Default `typeMap` covers the LLM-wiki shape (`person → Person`, `project → CreativeWork`, `theme/bit/career → Article`, etc.) and is fully overridable via the `typeMap` option for any other vocabulary. Also emits a `BreadcrumbList` derived from the slug path and a homepage-only `WebSite` block. Frontmatter passthrough for `image`, `sameAs`, `author`, `datePublished`, `dateModified`.

No markdown or HTML transformation — pure `externalResources.additionalHead` injection.

## Quality / docs

- 61 vitest cases passing
- `npm run check` (typecheck + ESLint + Prettier + tests) clean
- MIT licensed
- [README](https://github.com/billhector/quartz-schema-jsonld/blob/main/README.md), [CHANGELOG](https://github.com/billhector/quartz-schema-jsonld/blob/main/CHANGELOG.md), [v0.1.0 release](https://github.com/billhector/quartz-schema-jsonld/releases/tag/v0.1.0)

## Production use

Running on [robbylore.org](https://robbylore.org) (fan wiki). View source on any page to see the emitted `@graph` block.

Follows the contributing.md format: entry appended at the bottom of the section, beginning with a capital, ending in a period.
