### PR TITLE
Add Mindmap plugin to Quartz plugins list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,7 @@ Quartz is a fast, batteries-included static-site generator that transforms Markd
 - [Jupyter Notebook Embed](https://github.com/vazome/quartz-jupyter-embed-display) - A minimal Quartz plugin for embedding and displaying Jupyter notebooks.
 - [Code Runner](https://github.com/Gassandrid/Quartz_CodeRunner_Plugin) - A simple, asynchronous Python code runner plugin for Quartz. This plugin allows you to run Python code blocks directly within your Quartz notes, providing a convenient way to execute and view the output of your Python scripts.
 - [Auto Card Link Renderer](https://github.com/Rerurate514/AutoCardLinkRenderer) - It enables rendering of the Obsidian plugin: AutoCardLinkTitle in Quartz.
+- [Mindmap](https://github.com/om-mapari/quartz-v5-mindmap) - Interactive Mindmap plugin for Quartz 5 that renders Markdown headings and lists as visual diagrams using Markmap, supporting both local sidebar panel and global fullscreen portal overlay with hotkeys.
 
 <!-- END CONTENT -->
 


### PR DESCRIPTION
Added the quartz-v5-mindmap plugin to the list of community Quartz plugins in the README. This plugin renders markdown headings and lists as visual mindmap panels using Markmap (D3.js).